### PR TITLE
fix: return type annotation for encrypt

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -255,7 +255,7 @@ export default class Phase {
   encrypt = async (
     plaintext: string,
     tag: string = ""
-  ): Promise<PhaseCiphertext | undefined> => {
+  ): Promise<PhaseCiphertext> => {
     await _sodium.ready;
     const sodium = _sodium;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase.dev/phase-node",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Node.js Server SDK for Phase",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/version.ts
+++ b/version.ts
@@ -1,8 +1,1 @@
-/*
-DO NOT UPDATE THIS VALUE MANUALLY
-
-This value is automatically updated by the `prebuild` script based on the package version.
-Running the build script will automatically update this.
-*/
-
-export const LIB_VERSION = "0.2.1";
+export const LIB_VERSION = "0.2.2";


### PR DESCRIPTION
Fixed the return type annotation for `encrypt()`. The encrypt function either resolves in a `PhaseCiphertext` or rejects.