### PR TITLE
feat: zero keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,17 @@ const ciphertext = await phase.encrypt("hello world");
 ```js
 const plaintext = await phase.decrypt(ciphertext);
 ```
+
+## Development
+
+### Install dependencies
+
+`npm install`
+
+### Build
+
+`npm run build`
+
+### Run tests
+
+`npm test`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase.dev/phase-node",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "Node.js Server SDK for Phase",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,11 @@ export default class Phase {
           symmetricKeys.sharedTx
         );
 
+        // Use sodium.memzero to wipe the keys from memory
+        sodium.memzero(oneTimeKeyPair.privateKey);
+        sodium.memzero(symmetricKeys.sharedTx);
+        sodium.memzero(symmetricKeys.sharedRx);
+
         resolve(
           `ph:${PH_VERSION}:${sodium.to_hex(
             oneTimeKeyPair.publicKey
@@ -117,7 +122,7 @@ export default class Phase {
         const sessionKeys = await serverSessionKeys(
           {
             publicKey: sodium.from_hex(this.appPubKey) as Uint8Array,
-            privateKey: sodium.from_hex(appPrivKey) as Uint8Array,
+            privateKey: appPrivKey,
           },
           sodium.from_hex(ciphertext.pubKey)
         );
@@ -126,6 +131,11 @@ export default class Phase {
           ciphertext.data,
           sessionKeys.sharedRx
         );
+
+        // Use sodium.memzero to wipe the keys from memory
+        sodium.memzero(sessionKeys.sharedRx);
+        sodium.memzero(sessionKeys.sharedTx);
+        sodium.memzero(appPrivKey);
 
         resolve(plaintext);
       } catch (error) {

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -159,14 +159,16 @@ const xorUint8Arrays = (a: Uint8Array, b: Uint8Array): Uint8Array => {
  * Reconstructs a secret given an array of shares
  *
  * @param {string[]} shares Array of shares encoded as hex string
- * @returns {string} The reconstructed secret as a hex-encoded string
+ * @returns {Uint8Array} The reconstructed secret
  */
-export const reconstructSecret = async (shares: string[]): Promise<string> => {
+export const reconstructSecret = async (
+  shares: string[]
+): Promise<Uint8Array> => {
   await _sodium.ready;
   const sodium = _sodium;
   const byteShares = shares.map((share) => sodium.from_hex(share));
 
   const secret = byteShares.reduce((prev, curr) => xorUint8Arrays(prev, curr));
 
-  return sodium.to_hex(secret);
+  return secret;
 };

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -39,11 +39,12 @@ describe("Phase", () => {
   });
 
   describe("Encryption", () => {
+    const APP_ID =
+      "phApp:v1:cd2d579490fd794f1640590220de86a3676fa7979d419056bc631741b320b701";
+    const APP_SECRET =
+      "pss:v1:a7a0822aa4a4e4d37919009264200ba6ab978d92c8b4f7db5ae9ce0dfaf604fe:801605dfb89822ff52957abe39949bcfc44b9058ad81de58dd54fb0b110037b4b2bbde5a1143d31bbb3895f72e4ee52f5bd:625d395987f52c37022063eaf9b6260cad9ca03c99609213f899cae7f1bb04e7";
+
     test("Check if Phase encrypt returns a valid ph", async () => {
-      const APP_ID =
-        "phApp:v1:cd2d579490fd794f1640590220de86a3676fa7979d419056bc631741b320b701";
-      const APP_SECRET =
-        "pss:v1:a7a0822aa4a4e4d37919009264200ba6ab978d92c8b4f7db5ae9ce0dfaf604fe:801605dfb89822ff52957abe39949bcfc44b9058ad81de58dd54fb0b110037b4b2bbde5a1143d31bbb3895f72e4ee52f5bd:625d395987f52c37022063eaf9b6260cad9ca03c99609213f899cae7f1bb04e7";
       const phase = new Phase(APP_ID, APP_SECRET);
       const plaintext = "Signal";
       const tag = "Phase Tag";
@@ -58,6 +59,20 @@ describe("Phase", () => {
       // Check if the one-time public key and ciphertext are valid hex strings
       expect(segments[2]).toMatch(/^[0-9a-f]+$/);
       expect(segments[3]).toMatch(/^[0-9a-f]+$/);
+    });
+
+    test("Check if Phase encrypt always produces ciphertexts (ph:*) of the same length for the same plaintext", async () => {
+      const phase = new Phase(APP_ID, APP_SECRET);
+      const data = "hello world";
+      const numOfTrials = 10;
+      const ciphertextLengths = new Set<number>();
+
+      for (let i = 0; i < numOfTrials; i++) {
+        const ciphertext = await phase.encrypt(data);
+        ciphertextLengths.add((ciphertext as string).length);
+      }
+
+      expect(ciphertextLengths.size).toBe(1);
     });
   });
 

--- a/version.ts
+++ b/version.ts
@@ -1,1 +1,1 @@
-export const LIB_VERSION = "0.3.0";
+export const LIB_VERSION = "1.0.0";


### PR DESCRIPTION
* Updated `reconstructSecret` util to return a `Uint8Array` to skip unnecessarily encoding and decoding to hex
* Zero sensitive keys in memory during encrypt and decrypt
* Add test to validate ciphertext length when encrypting the same plaintext input
* Added dev instructions to readme
* Bumped package version to `1.0.0`