### PR TITLE
BREAKING CHANGE: use base64 encoding for data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase.dev/phase-node",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Node.js Server SDK for Phase",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -71,7 +71,10 @@ export const encryptString = async (plaintext: string, key: Uint8Array) => {
   await _sodium.ready;
   const sodium = _sodium;
 
-  return sodium.to_hex(await encryptRaw(sodium.from_string(plaintext), key));
+  return sodium.to_base64(
+    await encryptRaw(sodium.from_string(plaintext), key),
+    sodium.base64_variants.ORIGINAL
+  );
 };
 
 /**
@@ -85,7 +88,12 @@ export const decryptString = async (cipherText: string, key: Uint8Array) => {
   await _sodium.ready;
   const sodium = _sodium;
 
-  return sodium.to_string(await decryptRaw(sodium.from_hex(cipherText), key));
+  return sodium.to_string(
+    await decryptRaw(
+      sodium.from_base64(cipherText, sodium.base64_variants.ORIGINAL),
+      key
+    )
+  );
 };
 
 /**

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -58,7 +58,9 @@ describe("Phase", () => {
       expect(segments[4]).toBe(tag);
       // Check if the one-time public key and ciphertext are valid hex strings
       expect(segments[2]).toMatch(/^[0-9a-f]+$/);
-      expect(segments[3]).toMatch(/^[0-9a-f]+$/);
+      expect(segments[3]).toMatch(
+        /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/
+      );
     });
 
     test("Check if Phase encrypt always produces ciphertexts (ph:*) of the same length for the same plaintext", async () => {

--- a/version.ts
+++ b/version.ts
@@ -1,1 +1,1 @@
-export const LIB_VERSION = "1.0.0";
+export const LIB_VERSION = "2.0.0";


### PR DESCRIPTION
## Description

Replaces hex encoding with base64 to optimize the size of ciphertext strings.

## Changes

* Updated the `encryptString` and `decryptString` utils to use b64 encoding / decoding instead of hex
* Updated the regex in the tests to validate that the ciphertext is a base64 string
* Bumped the package version to `2.0.0`