### PR TITLE
feat: add support for custom kms hosts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase.dev/phase-node",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Node.js Server SDK for Phase",
   "main": "dist/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/utils/wrappedShare.ts
+++ b/src/utils/wrappedShare.ts
@@ -13,12 +13,13 @@ export const fetchAppKeyShare = async (
   appToken: string,
   wrapKey: string,
   appId: string,
-  dataSize: number
+  dataSize: number,
+  host: string
 ) => {
   await _sodium.ready;
   const sodium = _sodium;
 
-  const PHASE_KMS_URI = `https://kms.phase.dev/${appId}`;
+  const PHASE_KMS_URI = `${host}/${appId}`;
 
   const headers = {
     Authorization: `Bearer ${appToken}`,

--- a/version.ts
+++ b/version.ts
@@ -1,1 +1,1 @@
-export const LIB_VERSION = "2.0.1";
+export const LIB_VERSION = "2.1.0";


### PR DESCRIPTION
## Description

Adds support for using a custom KMS host. 

This PR allows initializing the Phase client with an optional kms host:
`const phase = new Phase(APP_ID, APP_SECRET, KMS_HOST)`

